### PR TITLE
Two links displayed when brand_logo_path option is used

### DIFF
--- a/macros_topbar.html
+++ b/macros_topbar.html
@@ -41,8 +41,9 @@
 			<a class="nav-link brand-link [#BRAND_LINK_CLASS]" href="[%URLDIFFUSEURSITE]">
 				<IF COND="[%BRAND_LOGO_PATH]">
 					<img class="brand-logo" src="[%BRAND_LOGO_PATH]" alt="[%DIFFUSEURSITE]">
+				<ELSE/>
+					<span class="brand-name">[%DIFFUSEURSITE]</span>
 				</IF>
-				<span class="brand-name">[%DIFFUSEURSITE]</span>
 			</a>
 		</li>
 	</IF>


### PR DESCRIPTION
Lorsqu'on active l'option brand_logo_path et qu'on définit le chemin d'une image pour le lien du diffuseur, celle-ci vient s'ajouter au lien texte existant au lieu de le remplacer.