### PR TITLE
Fix doi display

### DIFF
--- a/macros_base.html
+++ b/macros_base.html
@@ -657,7 +657,10 @@
 		</LOOP>
 	</LET>
 
-	<IF COND="[%PREFIXEDOI] AND [#TYPE] EQ 'article'">
+	<IF COND="[%SHOW_DOI_FOR_TYPES] LIKE /([^,]+)/">
+		<LET VAR="showthistype"><LOOP NAME="foreach" ARRAY="[#MATCHES.1]"><IF COND="[#TYPE] EQ [#VALUE|trim]">1</IF></LOOP></LET>
+	</IF>
+	<IF COND="[%PREFIXEDOI] AND [#SHOWTHISTYPE] AND ![#PARAITRE]">
 		<LET VAR="coins_doi">&amp;rft_id=info:doi/[%PREFIXEDOI][#ID]</LET>
 	</IF>
 

--- a/macros_base.html
+++ b/macros_base.html
@@ -671,7 +671,7 @@
 	<IF COND="[%SHOW_DOI_FOR_TYPES] LIKE /([^,]+)/">
 		<LET VAR="showthistype"><LOOP NAME="foreach" ARRAY="[#MATCHES.1]"><IF COND="[#TYPE] EQ [#VALUE|trim]">1</IF></LOOP></LET>
 	</IF>
-	<IF COND="[%PREFIXEDOI] AND [#SHOWTHISTYPE]">
+	<IF COND="[%PREFIXEDOI] AND [#SHOWTHISTYPE] AND ![#PARAITRE]">
 		<p class="doi">DOI&nbsp;: <a href="https://dx.doi.org/[%PREFIXEDOI][#ID]">[%PREFIXEDOI][#ID]</a></p>
 	</IF>
 </DEFMACRO>

--- a/macros_head.html
+++ b/macros_head.html
@@ -296,7 +296,7 @@
 	<IF COND="[%SHOW_DOI_FOR_TYPES] LIKE /([^,]+)/">
 		<LET VAR="showthistype"><LOOP NAME="foreach" ARRAY="[#MATCHES.1]"><IF COND="[#TYPE] EQ [#VALUE|trim]">1</IF></LOOP></LET>
 	</IF>
-	<IF COND="[%PREFIXEDOI] AND [#SHOWTHISTYPE]">
+	<IF COND="[%PREFIXEDOI] AND [#SHOWTHISTYPE] AND ![#PARAITRE]">
 		<meta name="[#NAME_VALUE]" content="doi:[%PREFIXEDOI][#ID]" />
 	</IF>
 </DEFFUNC>


### PR DESCRIPTION
1er patch : Le doi de numero s'affiche aussi pour les numéro à paraitre.
2ème patch : pour que l'insertion du paramètre doi dans l'url des COINS tienne compte du type de document
